### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/multiplayer.ts
+++ b/src/multiplayer.ts
@@ -63,7 +63,11 @@ export class MultiplayerManager {
     const host = window.location.host;
     const hostname = window.location.hostname;
     // Render.com or any production: always use relative /ws
-    if (hostname.includes('.onrender.com') || !host.includes('localhost')) {
+    if (
+      hostname === 'onrender.com' ||
+      hostname.endsWith('.onrender.com') ||
+      (!host.includes('localhost'))
+    ) {
       return '/ws';
     }
     // If running in development (localhost:5173), try local server


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/generated-game-experiment/security/code-scanning/5](https://github.com/commjoen/generated-game-experiment/security/code-scanning/5)

The best way to fix the problem is to avoid substring matching and instead check for exact matches against a whitelist of allowed hostnames or domains, or use a robust method to verify that the hostname is either exactly `onrender.com` or a subdomain of it. This can be done by splitting the hostname into its components and checking if it ends with `.onrender.com` (but not just contains it). The change should be made in the `getDefaultServerUrl` method, specifically on line 66 where the check is performed. No new methods are needed, but a helper function or a simple check using `endsWith` can be used. No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
