### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/generated-game-experiment/security/code-scanning/4](https://github.com/commjoen/generated-game-experiment/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions. The best way to do this is to add the block at the root level of the workflow file (above or below the `on:` block, but before `jobs:`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to check out code but not modify repository contents. No additional imports or definitions are needed; simply add the following block:

```yaml
permissions:
  contents: read
```

This should be placed after the `name:` and before `on:` or after `on:` and before `jobs:`. Either location is valid, but placing it after `name:` and before `on:` is conventional.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
