### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/generated-game-experiment/security/code-scanning/2](https://github.com/commjoen/generated-game-experiment/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or to the specific job. Since only the deploy step requires write access to `contents`, the best practice is to set the default permissions to `contents: read` at the workflow level, and override it for the `build-and-deploy` job (or just for the deploy step) to `contents: write`. However, GitHub Actions only allows setting permissions at the workflow or job level, not per step. Therefore, set `permissions: contents: write` for the `build-and-deploy` job, as it needs to push to the `gh-pages` branch. If you want to be even more restrictive, you could set `contents: read` at the workflow level and override it for the job, but since there is only one job, simply add the block to the job.

Edit `.github/workflows/deploy.yml` and add the following under the `build-and-deploy` job (line 9), before `runs-on: ubuntu-latest`:

```yaml
permissions:
  contents: write
```

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
