### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -1,4 +1,6 @@
 name: Docker Hub Release
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/generated-game-experiment/security/code-scanning/7](https://github.com/commjoen/generated-game-experiment/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to read repository contents (for actions/checkout and docker/metadata-action), so the minimal permission is `contents: read`. This block should be added at the root level (just after the `name:` and before `on:`) to apply to all jobs in the workflow. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
